### PR TITLE
add hover interaction to images in hexagon

### DIFF
--- a/components/hex.tsx
+++ b/components/hex.tsx
@@ -146,6 +146,7 @@ export default function Hex({
               patternTransform={`translate(${imageDx} ${imageDy})`}
             >
               <image
+                className="hex-image"
                 href={image}
                 x={`${0 + imgOffsetX}`}
                 y={`${0 + imgOffsetY}`}

--- a/styles/main.css
+++ b/styles/main.css
@@ -137,6 +137,15 @@ a:hover {
   z-index: 800;
 }
 
+.hex-image {
+  transition: transform 0.3s ease;
+}
+
+.hex-container svg:hover .hex-image {
+  transform: scale(1.1);
+  transition: transform 0.3s ease;
+}
+
 .dummy-card {
   width: 300px;
   height: 300px;


### PR DESCRIPTION
This PR adds hover interactions to all images on the website enclosed in a hexagon component! This includes all pages, as well as the pictures throughout the about page.